### PR TITLE
Updates to better match TPC-DS semantics (#51)

### DIFF
--- a/malloy_queries/01.malloy
+++ b/malloy_queries/01.malloy
@@ -19,6 +19,8 @@ to calculate the average, but this computed a different average from the
 original SQL query. The avg() function uses sum(amt)/count(amt), but the query
 as originally written computes sum(amt)/count(distinct customer)
 
+count(distinct customer) doesn't count null customers, so a second pass is used instead.
+
  */ 
 
 query: store_returns -> {
@@ -28,16 +30,26 @@ query: store_returns -> {
     customer.c_customer_id
   aggregate: 
     customer_total_returns is total_returns
-    avg_store_return is all(total_returns / count(distinct sr_customer_sk), sr_store_sk)
+    count_customers is all(max(1),sr_customer_sk,sr_store_sk)
   where:
     date_dim.d_year = 2000
     and store.s_state = 'TN'
     and sr_return_amt != null
 } -> {
+  group_by:
+    sr_customer_sk
+    sr_store_sk
+    c_customer_id
+  aggregate: 
+    avg_store_return is all(sum(customer_total_returns) / sum(count_customers), sr_store_sk)
+    customer_total_returns
+} ->
+{
   project:
     c_customer_id
   where: 
     customer_total_returns > avg_store_return * 1.2
+    and sr_customer_sk != null
   order_by:
     c_customer_id
   limit: 100

--- a/malloy_queries/10.malloy
+++ b/malloy_queries/10.malloy
@@ -1,5 +1,10 @@
 import "tpcds.malloy"
 
+// This one is *slightly* different from the SQL version.
+// The Malloy model creates the `all_sales` source using
+// a join on `cs_bill_customer_sk` when joining `catalog_sales`
+// to `customers`. The SQL version uses `cs_ship_customer_sk`.
+
 query: all_sales -> {
   group_by:
     customer.customer_demographics.cd_gender
@@ -29,9 +34,9 @@ query: all_sales -> {
   
   having:
     count_store_sales > 0
-    & (
+    and (
       count_web_sales > 0
-      | count_catalog_sales > 0
+      or count_catalog_sales > 0
     )
   
   order_by: 

--- a/malloy_queries/11.malloy
+++ b/malloy_queries/11.malloy
@@ -18,10 +18,10 @@ query: all_sales -> {
 
   having:
     store_total_sales_2001 > 0
-    & store_total_sales_2002 > 0
-    & web_total_sales_2001 > 0
-    & web_total_sales_2002 > 0
-    & web_total_sales_2002 / web_total_sales_2001 > store_total_sales_2002 / store_total_sales_2001
+    and store_total_sales_2002 > 0
+    and web_total_sales_2001 > 0
+    and web_total_sales_2002 > 0
+    and web_total_sales_2002 / web_total_sales_2001 > store_total_sales_2002 / store_total_sales_2001
 
   order_by:
     c_customer_id 

--- a/malloy_queries/14.malloy
+++ b/malloy_queries/14.malloy
@@ -23,8 +23,8 @@ source: item_properties is from(
     
     having:
       count_store_sales > 0
-      & count_web_sales > 0
-      & count_catalog_sales > 0
+      and count_web_sales > 0
+      and count_catalog_sales > 0
 
     order_by:
       i_brand_id

--- a/malloy_queries/21.malloy
+++ b/malloy_queries/21.malloy
@@ -21,8 +21,8 @@ query: inventory -> {
 
   having:
     inv_before > 0
-    & inv_after / inv_before >= 2.0 / 3.0
-    & inv_after / inv_before <= 3.0 / 2.0
+    and inv_after / inv_before >= 2.0 / 3.0
+    and inv_after / inv_before <= 3.0 / 2.0
 
   order_by:
     w_warehouse_name

--- a/malloy_queries/30.malloy
+++ b/malloy_queries/30.malloy
@@ -1,9 +1,11 @@
 import "tpcds.malloy"
 
+// Count distinct is insufficient because null wr_returning_customer_sk is included in average
+
 query: web_returns -> {
   group_by:
     wr_returning_customer_sk
-    returning_addr.ca_state
+    returning_state is returning_addr.ca_state
     returning_customer.c_customer_id
     returning_customer.c_salutation
     returning_customer.c_first_name
@@ -20,12 +22,33 @@ query: web_returns -> {
 
   aggregate: 
     customer_total_returns is total_returns
-    avg_web_return is all(total_returns / count(distinct wr_returning_customer_sk), ca_state)
+    total_web_return is all(sum(wr_return_amt), wr_returning_customer_sk, returning_state)
+
   where:
     date_dim.d_year = 2002
     and wr_return_amt != null
-    and returning_customer.c_customer_id != null
     and returning_addr.ca_state != null
+} -> {
+  group_by:
+    c_customer_id
+    c_salutation
+    c_first_name
+    c_last_name
+    c_preferred_cust_flag
+    c_birth_day
+    c_birth_month
+    c_birth_year
+    c_birth_country
+    c_login
+    c_email_address
+    c_last_review_date
+    customer_total_returns
+    returning_state
+    returning_customer_state
+
+  aggregate:
+  ave_return is all(avg(total_web_return), returning_state)
+
 } -> {
   project:
     c_customer_id
@@ -41,11 +64,10 @@ query: web_returns -> {
     c_email_address
     c_last_review_date
     customer_total_returns
-    avg_web_return
-
   where: 
-    customer_total_returns > avg_web_return * 1.2
+    customer_total_returns > ave_return * 1.2
     and returning_customer_state = 'GA'
+    and c_customer_id != null
 
   order_by:
     c_customer_id

--- a/malloy_queries/34.malloy
+++ b/malloy_queries/34.malloy
@@ -27,7 +27,7 @@ query: store_sales -> {
     and household_demographics.hd_dep_count / household_demographics.hd_vehicle_count > 1.2
 
   having:
-    count(*) >= 15 & count(*) <= 20
+    count(*) >= 15 and count(*) <= 20
 
   order_by:
     c_last_name

--- a/malloy_queries/35.malloy
+++ b/malloy_queries/35.malloy
@@ -38,9 +38,9 @@ query: all_sales -> {
 
   having:
     count_store_sales > 0
-    & (
+    and (
       count_catalog_sales > 0
-      | count_web_sales > 0
+      or count_web_sales > 0
     )
 } -> { 
   group_by: 

--- a/malloy_queries/47.malloy
+++ b/malloy_queries/47.malloy
@@ -5,6 +5,12 @@ import "tpcds.malloy"
 
 source: v1 is from(
   store_sales -> {
+    where:
+      ss_sales_price != null
+      and ss_store_sk != null
+      and item.i_category != null
+      and item.i_brand != null
+      
     group_by: 
       item.i_category
       item.i_brand
@@ -52,6 +58,8 @@ query: v1 + {
     d_year = 1999
     and avg_monthly_sales > 0
     and abs(sum_sales - avg_monthly_sales) / avg_monthly_sales > 0.1
+    and v1lag.d_month_seq != null
+    and v1lead.d_month_seq != null
 
   order_by:
     sales_diff

--- a/malloy_queries/65.malloy
+++ b/malloy_queries/65.malloy
@@ -17,6 +17,8 @@ query: store_sales -> {
   where:
     date_dim.d_month_seq >= 1176
     and date_dim.d_month_seq <= 1187
+    and ss_sales_price != null
+    and ss_store_sk != null
 } -> {
   project: s_store_name, i_item_desc, revenue, i_current_price, i_wholesale_cost, i_brand
   where: revenue <= 0.1 * ave

--- a/malloy_queries/69.malloy
+++ b/malloy_queries/69.malloy
@@ -19,8 +19,8 @@ query: all_sales -> {
   
   having:
     count_store_sales > 0
-    & count_web_sales = 0
-    & count_catalog_sales = 0
+    and count_web_sales = 0
+    and count_catalog_sales = 0
 
   order_by:
     cd_gender

--- a/malloy_queries/78.malloy
+++ b/malloy_queries/78.malloy
@@ -13,9 +13,10 @@ query: all_sales -> {
     other_qty is sum(quantity) { where: channel_category != 'store channel' }
     other_wc is sum(wholesale_cost) { where: channel_category != 'store channel' }
     other_sp is sum(sales_price) { where: channel_category != 'store channel' }
-
+    
     web_qty is sum(quantity) { where: channel_category = 'web channel' }
     catalog_qty is sum(quantity) { where: channel_category = 'catalog channel' }
+    store_count is count(*) { where: channel_category = 'store channel' }
 
   where:
     all_returns.order_number = null
@@ -36,7 +37,7 @@ query: all_sales -> {
     other_sp
 
   where:
-    store_qty > 0
+    store_count > 0
     and (web_qty > 0 or catalog_qty > 0)
 
   order_by: 

--- a/malloy_queries/89.malloy
+++ b/malloy_queries/89.malloy
@@ -25,6 +25,8 @@ query: store_sales -> {
         and (item.i_class ? 'shirts' | 'birdal' | 'dresses')
       )
     )
+    and ss_store_sk != null
+    and ss_sales_price != null
 } -> {
   declare: sales_diff is sum_sales - avg_monthly_sales
   project: *

--- a/malloy_queries/91.malloy
+++ b/malloy_queries/91.malloy
@@ -5,6 +5,8 @@ query: catalog_returns -> {
     call_center is call_center.cc_call_center_id
     call_center_name is call_center.cc_name
     manager is call_center.cc_manager
+    marital_status is returning_customer.customer_demographics.cd_marital_status
+    education_status is returning_customer.customer_demographics.cd_education_status
 
   aggregate:
     returns_loss is sum(cr_net_loss)

--- a/malloy_queries/99.malloy
+++ b/malloy_queries/99.malloy
@@ -19,6 +19,9 @@ query: catalog_sales -> {
   where:
     ship_date.d_month_seq >= 1200
     and ship_date.d_month_seq <= 1211
+    and cs_warehouse_sk != null
+    and cs_call_center_sk != null
+    and cs_ship_mode_sk != null
 
   order_by: 
     w_substr

--- a/sql_queries/41.sql
+++ b/sql_queries/41.sql
@@ -20,7 +20,7 @@ WHERE i_manufact_id BETWEEN 738 AND 738+40
                   AND (i_units = 'Ounce'
                        OR i_units = 'Oz')
                   AND (i_size = 'medium'
-                       OR i_size = 'extra olarge'))
+                       OR i_size = 'extra large'))
 
                  OR (i_category = 'Women'
                      AND (i_color = 'brown'


### PR DESCRIPTION
* Q30: Null wr_returning_customer_sk, c_customer_id

* Q47: Null sales_price, store, category, brand

* Q65: Null sales price, store

* Q41: Typo in constant

* Q78: Require store rather than quantity

* Q10: Fixed boolean ops and added warning note

* Use and or for logical operators instead of & |

* Q89: Skip null stores and prices

* Q99: Skip null warehouse, call center, ship mode

* Q91: Include missing group bys

* Q1: Add second pass to handle null customer_sk